### PR TITLE
fix: Update dependency @types/ramda to version 0.24.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/immutable": "3.8.7",
     "@types/inquirer": "0.0.34",
     "@types/node": "7.0.33",
-    "@types/ramda": "0.0.9",
+    "@types/ramda": "0.24.2",
     "immutable": "3.8.1",
     "inquirer": "3.1.1",
     "ramda": "0.24.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@
   version "7.0.33"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.33.tgz#ae3c53ad01d7e9d62c7f1a85c5f7500d59b9d25b"
 
-"@types/ramda@0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.0.9.tgz#c1b56c643688bf1c27a543ccfbc502cbda6772b6"
+"@types/ramda@0.24.2":
+  version "0.24.2"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.24.2.tgz#cce538e8fef2e85e04d16a169de8c717fe243620"
 
 "@types/rx-core-binding@*":
   version "4.0.4"


### PR DESCRIPTION
<p>This Pull Request updates dependency [@types/ramda]() from version <code>0.0.9</code> to <code>0.24.2</code></p>
<h3 id="commits">Commits</h3>
<p><details><br />
<summary>DefinitelyTyped/DefinitelyTyped</summary></p>
<h4 id="0242">0.24.2</h4>
<ul>
<li><a href="https://github.com/DefinitelyTyped/DefinitelyTyped/commit/a008b1cb19fb45f659fcd4231208a32966a5c565"><code>a008b1c</code></a> Merge pull request <a href="undefined/issues/17771">#17771</a> from ikatyang/jsonpath-patch</li>
<li><a href="https://github.com/DefinitelyTyped/DefinitelyTyped/commit/710098f96b8a7217dc2be6c7bac1de30c14c8d69"><code>710098f</code></a> add react-native-communications</li>
<li><a href="https://github.com/DefinitelyTyped/DefinitelyTyped/commit/a83680196054bffe4945402e3de189dbc07cd496"><code>a836801</code></a> Fixing react-native TextInput style</li>
<li><a href="https://github.com/DefinitelyTyped/DefinitelyTyped/commit/9cbb40a0809b76c5dcc2743ef3588ed4f302fe5e"><code>9cbb40a</code></a> Browser and Hash RouterProps is TS specific.</li>
<li><a href="https://github.com/DefinitelyTyped/DefinitelyTyped/commit/99733b174685b886128ffba4e6b2f33a35fd2d0d"><code>99733b1</code></a> Expose &#x60;BrowserRouterProps&#x60; and &#x60;HashRouterProps&#x60; interface.</li>
</ul>
<h4 id="0241">0.24.1</h4>
<h4 id="0240">0.24.0</h4>
<h4 id="0015">0.0.15</h4>
<h4 id="0014">0.0.14</h4>
<h4 id="0013">0.0.13</h4>
<h4 id="0012">0.0.12</h4>
<h4 id="0011">0.0.11</h4>
<h4 id="0010">0.0.10</h4>
<p></details><br />
<br /></p>
<p>This PR has been generated by <a href="https://keylocation.sg/our-tech/renovate">Renovate Bot</a>.</p>